### PR TITLE
fix bit shifting

### DIFF
--- a/AD5660.cpp
+++ b/AD5660.cpp
@@ -186,10 +186,10 @@ void AD5660::swSPI_transfer(uint32_t value)
 {
   uint8_t clk = _clock;
   uint8_t dao = _dataOut;
-  //  24 bit
-  for (uint32_t mask = 0x800000; mask; mask >>= 1)
+  //  Shifting 24 bits starting from MSB to LSB
+  for (uint8_t bit = 24; bit; bit--)
   {
-    digitalWrite(dao,(value & mask));
+    digitalWrite(dao, (value >> (bit - 1)) & 0x01);
     digitalWrite(clk, HIGH);
     digitalWrite(clk, LOW);
   }


### PR DESCRIPTION
**Issue description:** AD5660 reaches about 11 mV no matter what value is sent via software SPI
**Hardware:** esp32 (Lilygo T-Displat S3) and AD5660CRMZ-1
**Software:** Platformio 3.3.4 and Arduino framework for esp32
**Expectation:** full scale levels between 0 and 2.5V
**Solution:** fixing issue with serial shifting of the software SPI